### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/bin/make-rockyou-full.py
+++ b/bin/make-rockyou-full.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # utility script that creates the full rockyou leak using the word count
 # redirect this output to a file to save it. Once you do that it is recommended
 # to 'sort -R' to randomize it.

--- a/bin/prep-data.py
+++ b/bin/prep-data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import random
 

--- a/sample.py
+++ b/sample.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import time
 import pickle
@@ -10,6 +11,7 @@ import tflib.ops.linear
 import tflib.ops.conv1d
 import utils
 import models
+from utils import xrange
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/tflib/__init__.py
+++ b/tflib/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import tensorflow as tf
 
@@ -99,16 +100,16 @@ def delete_param_aliases():
 #     )
 
 def print_model_settings(locals_):
-    print "Uppercase local vars:"
+    print("Uppercase local vars:")
     all_vars = [(k,v) for (k,v) in locals_.items() if (k.isupper() and k!='T' and k!='SETTINGS' and k!='ALL_SETTINGS')]
     all_vars = sorted(all_vars, key=lambda x: x[0])
     for var_name, var_value in all_vars:
-        print "\t{}: {}".format(var_name, var_value)
+        print("\t{}: {}".format(var_name, var_value))
 
 
 def print_model_settings_dict(settings):
-    print "Settings dict:"
+    print("Settings dict:")
     all_vars = [(k,v) for (k,v) in settings.items()]
     all_vars = sorted(all_vars, key=lambda x: x[0])
     for var_name, var_value in all_vars:
-        print "\t{}: {}".format(var_name, var_value)
+        print("\t{}: {}".format(var_name, var_value))

--- a/tflib/cifar10.py
+++ b/tflib/cifar10.py
@@ -4,6 +4,7 @@ import os
 import urllib
 import gzip
 import cPickle as pickle
+from ..utils import xrange
 
 def unpickle(file):
     fo = open(file, 'rb')

--- a/tflib/mnist.py
+++ b/tflib/mnist.py
@@ -1,9 +1,11 @@
+from __future__ import print_function
 import numpy
 
 import os
 import urllib
 import gzip
 import cPickle as pickle
+from ..utils import xrange
 
 def mnist_generator(data, batch_size, n_labelled, limit=None):
     images, targets = data
@@ -13,7 +15,7 @@ def mnist_generator(data, batch_size, n_labelled, limit=None):
     numpy.random.set_state(rng_state)
     numpy.random.shuffle(targets)
     if limit is not None:
-        print "WARNING ONLY FIRST {} MNIST DIGITS".format(limit)
+        print("WARNING ONLY FIRST {} MNIST DIGITS".format(limit))
         images = images.astype('float32')[:limit]
         targets = targets.astype('int32')[:limit]
     if n_labelled is not None:
@@ -51,7 +53,7 @@ def load(batch_size, test_batch_size, n_labelled=None):
     url = 'http://www.iro.umontreal.ca/~lisa/deep/data/mnist/mnist.pkl.gz'
 
     if not os.path.isfile(filepath):
-        print "Couldn't find MNIST dataset in /tmp, downloading..."
+        print("Couldn't find MNIST dataset in /tmp, downloading...")
         urllib.urlretrieve(url, filepath)
 
     with gzip.open('/tmp/mnist.pkl.gz', 'rb') as f:

--- a/tflib/ops/batchnorm.py
+++ b/tflib/ops/batchnorm.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import tflib as lib
 
 import numpy as np
@@ -77,7 +78,7 @@ def Batchnorm(name, axes, inputs, is_training=None, stats_iter=None, update_movi
         mean, var = tf.nn.moments(inputs, axes, keep_dims=True)
         shape = mean.get_shape().as_list()
         if 0 not in axes:
-            print "WARNING ({}): didn't find 0 in axes, but not using separate BN params for each item in batch".format(name)
+            print("WARNING ({}): didn't find 0 in axes, but not using separate BN params for each item in batch".format(name))
             shape[0] = 1
         offset = lib.param(name+'.offset', np.zeros(shape, dtype='float32'))
         scale = lib.param(name+'.scale', np.ones(shape, dtype='float32'))

--- a/tflib/ops/conv1d.py
+++ b/tflib/ops/conv1d.py
@@ -3,6 +3,8 @@ import tflib as lib
 import numpy as np
 import tensorflow as tf
 
+from lib.utils import xrange
+
 _default_weightnorm = False
 def enable_default_weightnorm():
     global _default_weightnorm

--- a/tflib/ops/conv2d.py
+++ b/tflib/ops/conv2d.py
@@ -3,6 +3,8 @@ import tflib as lib
 import numpy as np
 import tensorflow as tf
 
+from lib.utils import xrange
+
 _default_weightnorm = False
 def enable_default_weightnorm():
     global _default_weightnorm

--- a/tflib/ops/layernorm.py
+++ b/tflib/ops/layernorm.py
@@ -2,6 +2,7 @@ import tflib as lib
 
 import numpy as np
 import tensorflow as tf
+from lib.utils import xrange
 
 def Layernorm(name, norm_axes, inputs):
     mean, var = tf.nn.moments(inputs, norm_axes, keep_dims=True)

--- a/tflib/plot.py
+++ b/tflib/plot.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import numpy as np
 
@@ -38,7 +39,7 @@ def flush():
 		plt.ylabel(name)
 		plt.savefig(os.path.join(output_dir, name.replace(' ', '_')+'.jpg'))
 
-	print "iter {}\t{}".format(_iter[0], "\t".join(prints))
+	print("iter {}\t{}".format(_iter[0], "\t".join(prints)))
 	_since_last_flush.clear()
 
 	with open(os.path.join(output_dir, 'log.pkl'), 'wb') as f:

--- a/tflib/small_imagenet.py
+++ b/tflib/small_imagenet.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import scipy.misc
 import time
@@ -27,7 +28,7 @@ if __name__ == '__main__':
     train_gen, valid_gen = load(64)
     t0 = time.time()
     for i, batch in enumerate(train_gen(), start=1):
-        print "{}\t{}".format(str(time.time() - t0), batch[0][0,0,0,0])
+        print("{}\t{}".format(str(time.time() - t0), batch[0][0,0,0,0]))
         if i == 1000:
             break
         t0 = time.time()

--- a/train.py
+++ b/train.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, sys
 sys.path.append(os.getcwd())
 
@@ -13,6 +14,7 @@ import tflib.ops.linear
 import tflib.ops.conv1d
 import tflib.plot
 import models
+from utils import xrange
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -141,7 +143,7 @@ def inf_train_gen():
 true_char_ngram_lms = [utils.NgramLanguageModel(i+1, lines[10*args.batch_size:], tokenize=False) for i in xrange(4)]
 validation_char_ngram_lms = [utils.NgramLanguageModel(i+1, lines[:10*args.batch_size], tokenize=False) for i in xrange(4)]
 for i in xrange(4):
-    print "validation set JSD for n={}: {}".format(i+1, true_char_ngram_lms[i].js_with(validation_char_ngram_lms[i]))
+    print("validation set JSD for n={}: {}".format(i+1, true_char_ngram_lms[i].js_with(validation_char_ngram_lms[i])))
 true_char_ngram_lms = [utils.NgramLanguageModel(i+1, lines, tokenize=False) for i in xrange(4)]
 
 with tf.Session() as session:
@@ -170,7 +172,7 @@ with tf.Session() as session:
 
         # Train critic
         for i in xrange(args.critic_iters):
-            _data = gen.next()
+            _data = next(gen)
             _disc_cost, _ = session.run(
                 [disc_cost, disc_train_op],
                 feed_dict={real_inputs_discrete:_data}

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,12 @@
+from __future__ import print_function
 import collections
 import numpy as np
 import re
+
+try:
+    xrange = xrange
+except NameError:
+    xrange = range
 
 def tokenize_string(sample):
     return tuple(sample.lower().split(' '))
@@ -130,5 +136,5 @@ def load_dataset(path, max_length, tokenize=False, max_vocab_size=2048):
     # for i in xrange(100):
     #     print filtered_lines[i]
 
-    print "loaded {} lines in dataset".format(len(lines))
+    print("loaded {} lines in dataset".format(len(lines)))
     return filtered_lines, charmap, inv_charmap


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There might be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
